### PR TITLE
Correct port mapping for RedisInsight in Docker Compose

### DIFF
--- a/redis/redis-docker-compose.yml
+++ b/redis/redis-docker-compose.yml
@@ -13,7 +13,7 @@ services:
     container_name: redis_insight
     restart: always
     ports:
-      - 8001:8001
+      - 5540:5540
     volumes:
       - redis_insight_volume_data:/db
 volumes:


### PR DESCRIPTION
This Pull Request addresses an issue found in the docker-compose.yml where the port mapping for RedisInsight was incorrectly set to 8001 instead of 5540. The correction ensures that RedisInsight is accessible at the proper port, thus avoiding connection issues and improving the setup's usability.

Changes:

Updated the port mapping for RedisInsight from 8001 to 5540 in the docker-compose.yml file.
This change is intended to align the configuration with the standard RedisInsight port settings recommended in the official documentation, enhancing compatibility and ease of use for new users setting up their environments.